### PR TITLE
Added a stateful event processor sample as alternative to a Saga

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>sequencing-policy</module>
         <module>multitenant-application</module>
         <module>set-based-validation-actor-model</module>
+        <module>stateful-event-handler</module>
     </modules>
     <packaging>pom</packaging>
 

--- a/stateful-event-handler/README.md
+++ b/stateful-event-handler/README.md
@@ -1,0 +1,13 @@
+# Stateful event processor implementation example
+
+This is an example on how to implement a stateful event processor, which could be used as an alternative to a [Saga](../saga). This use case is implemented in the [OrderProcessor](src/main/java/io/axoniq/dev/samples/orderprocessor/OrderProcessor.java).
+
+A webshop has different bounded contexts, for instance, a checkout (where the customer can add items to the card), an order, a shipment, a payment context. The checkout context will produce events based on actions that the customer does in the checkout. Some of these events are the so-called domain events. These events could trigger actions within other contexts. An example could be the [OrderConfirmedEvent](src/main/java/io/axoniq/dev/samples/order/api/OrderConfirmedEvent.java). When an order is confirmed, the order processing starts: the customer should pay, and the ordered articles need shipping. This process needs to be managed. When the order is not paid you need to take some compensating actions like cancelling the shipment.
+
+This stateful event processor is responsible for the process between multiple bounded contexts. It starts on the [OrderConfirmedEvent](src/main/java/io/axoniq/dev/samples/order/api/OrderConfirmedEvent.java) which marks the start of the order process and contains the `orderId`.
+
+The event-handling methods are annotated with `@EventHandler`. During this process, the [OrderProcess](src/main/java/io/axoniq/dev/samples/orderprocessor/OrderProcess.java) is stored in the database to maintain the state of an order process. In this example JPA is used, but you could use any alternative of your choosing here.
+
+## Stateful event processor configuration example
+
+An event processor will (by default) start its token at the head of the stream. It is possible to change this behavior and let the processor take all historical events into account. The configuration example can be found [here](src/main/java/io/axoniq/dev/samples/config/OrderProcessorConfig.java)

--- a/stateful-event-handler/README.md
+++ b/stateful-event-handler/README.md
@@ -10,4 +10,4 @@ The event-handling methods are annotated with `@EventHandler`. During this proce
 
 ## Stateful event processor configuration example
 
-An event processor will (by default) start its token at the head of the stream. It is possible to change this behavior and let the processor take all historical events into account. The configuration example can be found [here](src/main/java/io/axoniq/dev/samples/config/OrderProcessorConfig.java)
+An event processor will (by default) start its token at the tail of the stream. It is possible to change this behavior and let the processor start at the head instead, preventing earlier events from being processed, which could otherwise cause undesirable side effects. The configuration example can be found [here](src/main/java/io/axoniq/dev/samples/config/OrderProcessorConfig.java)

--- a/stateful-event-handler/pom.xml
+++ b/stateful-event-handler/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.axoniq</groupId>
+        <artifactId>code-samples</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>stateful-event-handler</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.axonframework</groupId>
+            <artifactId>axon-messaging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-jpa</artifactId>
+            <version>2.6.1</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/config/OrderProcessorConfig.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/config/OrderProcessorConfig.java
@@ -13,7 +13,7 @@ public class OrderProcessorConfig {
     public ConfigurerModule configureOrderProcessor() {
         TrackingEventProcessorConfiguration tepConfig =
                 TrackingEventProcessorConfiguration.forSingleThreadedProcessing()
-                        .andInitialTrackingToken(StreamableMessageSource::createTailToken);
+                        .andInitialTrackingToken(StreamableMessageSource::createHeadToken);
         return configurer -> configurer.eventProcessing().registerTrackingEventProcessorConfiguration("OrderProcessor", c -> tepConfig);
     }
 }

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/config/OrderProcessorConfig.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/config/OrderProcessorConfig.java
@@ -1,0 +1,19 @@
+package io.axoniq.dev.samples.config;
+
+import org.axonframework.config.ConfigurerModule;
+import org.axonframework.eventhandling.TrackingEventProcessorConfiguration;
+import org.axonframework.messaging.StreamableMessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OrderProcessorConfig {
+
+    @Bean
+    public ConfigurerModule configureOrderProcessor() {
+        TrackingEventProcessorConfiguration tepConfig =
+                TrackingEventProcessorConfiguration.forSingleThreadedProcessing()
+                        .andInitialTrackingToken(StreamableMessageSource::createTailToken);
+        return configurer -> configurer.eventProcessing().registerTrackingEventProcessorConfiguration("OrderProcessor", c -> tepConfig);
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/order/api/CompleteOrderProcessCommand.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/order/api/CompleteOrderProcessCommand.java
@@ -1,0 +1,20 @@
+package io.axoniq.dev.samples.order.api;
+
+import io.axoniq.dev.samples.uuid.OrderId;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+public class CompleteOrderProcessCommand {
+
+    @TargetAggregateIdentifier
+    OrderId orderId;
+
+    Boolean isPaid;
+
+    Boolean orderIsDelivered;
+
+    public CompleteOrderProcessCommand(OrderId orderId, Boolean isPaid, Boolean orderIsDelivered) {
+        this.orderId = orderId;
+        this.isPaid = isPaid;
+        this.orderIsDelivered = orderIsDelivered;
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/order/api/OrderConfirmedEvent.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/order/api/OrderConfirmedEvent.java
@@ -1,0 +1,17 @@
+package io.axoniq.dev.samples.order.api;
+
+
+import io.axoniq.dev.samples.uuid.OrderId;
+
+public class OrderConfirmedEvent {
+
+    OrderId orderId;
+
+    public OrderConfirmedEvent(OrderId orderId) {
+        this.orderId = orderId;
+    }
+
+    public OrderId getOrderId() {
+        return orderId;
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/orderprocessor/OrderProcess.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/orderprocessor/OrderProcess.java
@@ -1,0 +1,54 @@
+package io.axoniq.dev.samples.orderprocessor;
+
+import io.axoniq.dev.samples.uuid.OrderId;
+import io.axoniq.dev.samples.uuid.PaymentId;
+import io.axoniq.dev.samples.uuid.ShipmentId;
+
+import javax.persistence.Embedded;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+
+@Entity
+public class OrderProcess {
+    @EmbeddedId
+    private OrderId orderId;
+    @Embedded
+    private PaymentId paymentId;
+    @Embedded
+    private ShipmentId shipmentId;
+    private boolean orderIsPaid = false;
+    private boolean orderIsDelivered = false;
+
+    public OrderProcess(OrderId orderId, PaymentId paymentId, ShipmentId shipmentId) {
+        this.orderId = orderId;
+        this.paymentId = paymentId;
+        this.shipmentId = shipmentId;
+    }
+
+    public OrderProcess() { }
+
+    public void markAsPaid() {
+        orderIsPaid = true;
+    }
+
+    public void markAsDelivered() {
+        orderIsDelivered = true;
+    }
+
+    public boolean orderIsPaid() {
+        return orderIsPaid;
+    }
+
+    public boolean orderIsDelivered() {
+        return orderIsDelivered;
+    }
+
+    public OrderId getOrderId() {
+        return orderId;
+    }
+
+    public ShipmentId getShipmentId() {
+        return shipmentId;
+    }
+
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/orderprocessor/OrderProcessRepository.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/orderprocessor/OrderProcessRepository.java
@@ -1,0 +1,15 @@
+package io.axoniq.dev.samples.orderprocessor;
+
+import io.axoniq.dev.samples.uuid.OrderId;
+import io.axoniq.dev.samples.uuid.PaymentId;
+import io.axoniq.dev.samples.uuid.ShipmentId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface OrderProcessRepository extends JpaRepository<OrderProcess, OrderId> {
+    Optional<OrderProcess> findByPaymentId(PaymentId paymentId);
+    Optional<OrderProcess> findByShipmentId(ShipmentId shipmentId);
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/orderprocessor/OrderProcessor.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/orderprocessor/OrderProcessor.java
@@ -1,0 +1,86 @@
+package io.axoniq.dev.samples.orderprocessor;
+
+import io.axoniq.dev.samples.order.api.CompleteOrderProcessCommand;
+import io.axoniq.dev.samples.order.api.OrderConfirmedEvent;
+import io.axoniq.dev.samples.payment.api.OrderPaidEvent;
+import io.axoniq.dev.samples.payment.api.OrderPaymentCancelledEvent;
+import io.axoniq.dev.samples.payment.api.PayOrderCommand;
+import io.axoniq.dev.samples.shipment.api.CancelShipmentCommand;
+import io.axoniq.dev.samples.shipment.api.ShipOrderCommand;
+import io.axoniq.dev.samples.shipment.api.ShipmentStatus;
+import io.axoniq.dev.samples.shipment.api.ShipmentStatusUpdatedEvent;
+import io.axoniq.dev.samples.uuid.PaymentId;
+import io.axoniq.dev.samples.uuid.ShipmentId;
+import io.axoniq.dev.samples.uuid.UUIDProvider;
+import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.config.ProcessingGroup;
+import org.axonframework.eventhandling.EventHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@ProcessingGroup("OrderProcessor")
+public class OrderProcessor {
+    private final CommandGateway commandGateway;
+    private final OrderProcessRepository orderProcessRepository;
+
+    @Autowired
+    public OrderProcessor(CommandGateway commandGateway, OrderProcessRepository orderProcessRepository) {
+        this.commandGateway = commandGateway;
+        this.orderProcessRepository = orderProcessRepository;
+    }
+
+    @EventHandler
+    public void on(OrderConfirmedEvent event, UUIDProvider uuidProvider) {
+        //Send a command to paid to get the order paid.
+        PaymentId paymentId = uuidProvider.generatePaymentId();
+        commandGateway.send(new PayOrderCommand(paymentId));
+
+        //Send a command to logistics to ship the order.
+        ShipmentId shipmentId = uuidProvider.generateShipmentId();
+        commandGateway.send(new ShipOrderCommand(shipmentId));
+
+        OrderProcess orderProcess = new OrderProcess(event.getOrderId(), paymentId, shipmentId);
+        orderProcessRepository.save(orderProcess);
+    }
+
+    @EventHandler
+    public void on(OrderPaidEvent event) {
+        orderProcessRepository.findByPaymentId(event.getPaymentId()).ifPresent(
+                orderProcess -> {
+                    orderProcess.markAsPaid();
+                    if (orderProcess.orderIsDelivered()) {
+                        completeOrderProcess(orderProcess);
+                    }
+                });
+    }
+
+    @EventHandler
+    public void on(OrderPaymentCancelledEvent event) {
+        orderProcessRepository.findByPaymentId(event.getPaymentId()).ifPresent(
+                orderProcess -> {
+                    commandGateway.send(new CancelShipmentCommand(orderProcess.getShipmentId()));
+                    completeOrderProcess(orderProcess);
+                }
+        );
+    }
+
+    @EventHandler
+    public void on(ShipmentStatusUpdatedEvent event) {
+        if (ShipmentStatus.DELIVERED.equals(event.getShipmentStatus())) {
+            orderProcessRepository.findByShipmentId(event.getShipmentId()).ifPresent(
+                    orderProcess -> {
+                        orderProcess.markAsDelivered();
+                        if (orderProcess.orderIsPaid()) {
+                            completeOrderProcess(orderProcess);
+                        }
+                    }
+            );
+        }
+    }
+
+    private void completeOrderProcess(OrderProcess orderProcess) {
+        commandGateway.send(new CompleteOrderProcessCommand(orderProcess.getOrderId(), orderProcess.orderIsPaid(), orderProcess.orderIsDelivered()));
+        orderProcessRepository.delete(orderProcess);
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/payment/api/OrderPaidEvent.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/payment/api/OrderPaidEvent.java
@@ -1,0 +1,17 @@
+package io.axoniq.dev.samples.payment.api;
+
+
+import io.axoniq.dev.samples.uuid.PaymentId;
+
+public class OrderPaidEvent {
+
+    PaymentId paymentId;
+
+    public OrderPaidEvent(PaymentId paymentId) {
+        this.paymentId = paymentId;
+    }
+
+    public PaymentId getPaymentId() {
+        return paymentId;
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/payment/api/OrderPaymentCancelledEvent.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/payment/api/OrderPaymentCancelledEvent.java
@@ -1,0 +1,17 @@
+package io.axoniq.dev.samples.payment.api;
+
+
+import io.axoniq.dev.samples.uuid.PaymentId;
+
+public class OrderPaymentCancelledEvent {
+
+    PaymentId paymentId;
+
+    public OrderPaymentCancelledEvent(PaymentId paymentId) {
+        this.paymentId = paymentId;
+    }
+
+    public PaymentId getPaymentId() {
+        return paymentId;
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/payment/api/PayOrderCommand.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/payment/api/PayOrderCommand.java
@@ -1,0 +1,14 @@
+package io.axoniq.dev.samples.payment.api;
+
+import io.axoniq.dev.samples.uuid.PaymentId;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+public class PayOrderCommand {
+
+    @TargetAggregateIdentifier
+    PaymentId paymentId;
+
+    public PayOrderCommand(PaymentId paymentId) {
+        this.paymentId = paymentId;
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/shipment/api/CancelShipmentCommand.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/shipment/api/CancelShipmentCommand.java
@@ -1,0 +1,18 @@
+package io.axoniq.dev.samples.shipment.api;
+
+import io.axoniq.dev.samples.uuid.ShipmentId;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+public class CancelShipmentCommand {
+
+    @TargetAggregateIdentifier
+    ShipmentId shipmentId;
+
+    public CancelShipmentCommand(ShipmentId shipmentId) {
+        this.shipmentId = shipmentId;
+    }
+
+    public ShipmentId getShipmentId() {
+        return shipmentId;
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/shipment/api/ShipOrderCommand.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/shipment/api/ShipOrderCommand.java
@@ -1,0 +1,19 @@
+package io.axoniq.dev.samples.shipment.api;
+
+import io.axoniq.dev.samples.uuid.ShipmentId;
+import org.axonframework.modelling.command.TargetAggregateIdentifier;
+
+public class ShipOrderCommand {
+
+    @TargetAggregateIdentifier
+    ShipmentId shipmentId;
+
+
+    public ShipOrderCommand(ShipmentId shipmentId) {
+        this.shipmentId = shipmentId;
+    }
+
+    public ShipmentId getShipmentId() {
+        return shipmentId;
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/shipment/api/ShipmentStatus.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/shipment/api/ShipmentStatus.java
@@ -1,0 +1,8 @@
+package io.axoniq.dev.samples.shipment.api;
+
+public enum ShipmentStatus {
+    NEW,
+    SHIPPED,
+    DELIVERY_EXCEPTION,
+    DELIVERED
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/shipment/api/ShipmentStatusUpdatedEvent.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/shipment/api/ShipmentStatusUpdatedEvent.java
@@ -1,0 +1,24 @@
+package io.axoniq.dev.samples.shipment.api;
+
+
+import io.axoniq.dev.samples.uuid.ShipmentId;
+
+public class ShipmentStatusUpdatedEvent {
+
+    ShipmentId shipmentId;
+
+    ShipmentStatus shipmentStatus;
+
+    public ShipmentStatusUpdatedEvent(ShipmentId shipmentId, ShipmentStatus shipmentStatus) {
+        this.shipmentId = shipmentId;
+        this.shipmentStatus = shipmentStatus;
+    }
+
+    public ShipmentId getShipmentId() {
+        return shipmentId;
+    }
+
+    public ShipmentStatus getShipmentStatus() {
+        return shipmentStatus;
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/AbstractId.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/AbstractId.java
@@ -1,0 +1,14 @@
+package io.axoniq.dev.samples.uuid;
+
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+abstract class AbstractId implements Serializable {
+
+    UUID id;
+    public AbstractId() {
+        this.id = UUID.randomUUID();
+    }
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/OrderId.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/OrderId.java
@@ -1,0 +1,5 @@
+package io.axoniq.dev.samples.uuid;
+
+public class OrderId extends AbstractId {
+
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/PaymentId.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/PaymentId.java
@@ -1,0 +1,5 @@
+package io.axoniq.dev.samples.uuid;
+
+public class PaymentId extends AbstractId {
+
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/ShipmentId.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/ShipmentId.java
@@ -1,0 +1,5 @@
+package io.axoniq.dev.samples.uuid;
+
+public class ShipmentId extends AbstractId{
+
+}

--- a/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/UUIDProvider.java
+++ b/stateful-event-handler/src/main/java/io/axoniq/dev/samples/uuid/UUIDProvider.java
@@ -1,0 +1,19 @@
+package io.axoniq.dev.samples.uuid;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UUIDProvider {
+
+    public OrderId generateOrderId() {
+        return new OrderId();
+    }
+
+    public PaymentId generatePaymentId() {
+        return new PaymentId();
+    }
+
+    public ShipmentId generateShipmentId() {
+        return new ShipmentId();
+    }
+}


### PR DESCRIPTION
This PR takes the saga sample from this same repository and converts it into a stateful event handler instead, manually maintaining the state.

Since scheduling could be done in a large variety of ways with this sample, I have simply omitted the deadline and related logic from the saga example and just implemented the rest of the logic from this process.